### PR TITLE
fix: bypass login for BLE/UWB testing and fix UWB arrow direction

### DIFF
--- a/FindMyCat/Controllers/AddEditDevice/AddEditDeviceViewController.swift
+++ b/FindMyCat/Controllers/AddEditDevice/AddEditDeviceViewController.swift
@@ -213,6 +213,16 @@ class AddEditDeviceViewController: UIViewController, UITextFieldDelegate {
                 }
             }
         } else {
+            #if DEBUG
+            let bypassLogin = true
+            if bypassLogin {
+                let localDevice = Device(name: deviceName, id: 0, uniqueId: deviceUniqueId)
+                localDevice.attributes = Device.Attributes(emoji: emoji.isEmpty ? nil : emoji)
+                SharedData.addLocalDevice(localDevice)
+                self.navigationController?.dismiss(animated: true)
+                return
+            }
+            #endif
             TraccarAPIManager.shared.createDevice(name: deviceName, uniqueId: deviceUniqueId, emoji: emoji) {
                 response in
                 switch response {

--- a/FindMyCat/Controllers/PreciseFinder/extensions/NI_AR_SessionDelegates.swift
+++ b/FindMyCat/Controllers/PreciseFinder/extensions/NI_AR_SessionDelegates.swift
@@ -36,21 +36,27 @@ extension PreciseFinderViewContoller: NISessionDelegate {
 
     func session(_ session: NISession, didUpdateAlgorithmConvergence convergence: NIAlgorithmConvergence, for object: NINearbyObject?) {
         logger.log("Convergence Status: \(String(describing: convergence.status))")
-        // TODO: To Refactor delete to only know converged or not
-
-        guard let accessory = object else { return}
 
         switch convergence.status {
         case .converged:
-            logger.log("Converged")
             NIAlgorithmHasConverged = true
-        case .notConverged([NIAlgorithmConvergenceStatus.Reason.insufficientLighting]):
-            logger.log("More light required")
+            DispatchQueue.main.async {
+                self.searchingLabel.text = "Searching..."
+            }
+        case .notConverged(let reasons):
             NIAlgorithmHasConverged = false
-        default:
-            logger.log("Try moving in a different direction...")
+            DispatchQueue.main.async {
+                self.searchingLabel.text = self.convergenceHint(for: reasons)
+            }
+        @unknown default:
+            break
         }
+    }
 
+    private func convergenceHint(for reasons: [NIAlgorithmConvergenceStatus.Reason]) -> String {
+        if reasons.isEmpty { return "Searching..." }
+        if reasons.contains(.insufficientLighting) { return "Need more light" }
+        return "Move around"
     }
     func session(_ session: NISession, didUpdate nearbyObjects: [NINearbyObject]) {
         guard let accessory = nearbyObjects.first else { return }

--- a/FindMyCat/Controllers/PreciseFinder/extensions/NI_AR_SessionDelegates.swift
+++ b/FindMyCat/Controllers/PreciseFinder/extensions/NI_AR_SessionDelegates.swift
@@ -66,10 +66,9 @@ extension PreciseFinderViewContoller: NISessionDelegate {
                 searchingLabel.isHidden = true
                 updatedDevice.uwbLocation?.direction = direction
                 updatedDevice.uwbLocation?.noUpdate  = false
-            }
-            // TODO: For IPhone 14 only
-            else if NIAlgorithmHasConverged {
-                guard let horizontalAngle = accessory.horizontalAngle else {return}
+            } else if let horizontalAngle = accessory.horizontalAngle {
+                arrowImgView.isHidden = false
+                searchingLabel.isHidden = true
                 updatedDevice.uwbLocation?.direction = uwbUtilManager.getDirectionFromHorizontalAngle(rad: horizontalAngle)
                 updatedDevice.uwbLocation?.elevation = accessory.verticalDirectionEstimate.rawValue
                 updatedDevice.uwbLocation?.noUpdate  = false

--- a/FindMyCat/Models/SharedData.swift
+++ b/FindMyCat/Models/SharedData.swift
@@ -60,6 +60,10 @@ class SharedData {
         return self.devices
     }
 
+    public static func addLocalDevice(_ device: Device) {
+        devices.append(device)
+    }
+
     public static func getDevicesCount() -> Int {
         return self.devices.count
     }

--- a/FindMyCat/ViewController.swift
+++ b/FindMyCat/ViewController.swift
@@ -18,6 +18,13 @@ class ViewController: UIViewController {
     }
 
     private func showMainOrLoginScreen() {
+        #if DEBUG
+        let bypassLogin = true
+        if bypassLogin {
+            showMainScreen()
+            return
+        }
+        #endif
 
         TraccarAPIManager.shared.getSession {
             response in


### PR DESCRIPTION
- Add DEBUG bypass to skip login and device network creation for local testing
- Fix UWB arrow never showing on devices using horizontalAngle instead of direction vector
- Remove NIAlgorithmHasConverged gate on horizontalAngle, it's valid before full convergence

https://github.com/FindMyCat/planning/issues/21